### PR TITLE
SASS generates incorrectly

### DIFF
--- a/lib/sproutcore/builders/sass.rb
+++ b/lib/sproutcore/builders/sass.rb
@@ -36,7 +36,7 @@ module SC
         css = ::Sass::Engine.new(content, :syntax => @@sass_syntax, :load_paths => load_paths).render
         lines = []
         css.each_line { |l| lines << rewrite_inline_code(l) }
-        writelines dst_path, lines
+        writelines dst_path, lines.join
       rescue Exception => e
 
         # explain sass syntax error a bit more...


### PR DESCRIPTION
Under ruby 1.9, the Sass builder was outputting an array of strings into the generated CSS file.  This is because `Array#to_s` is now the same as `Array#inspect`.
