### PR TITLE
Allow handlebars templates to be in other locations

### DIFF
--- a/lib/buildtasks/manifest.rake
+++ b/lib/buildtasks/manifest.rake
@@ -145,6 +145,9 @@ namespace :manifest do
         end
       end
 
+      # allow if it is a handlebars template
+      next if entry[:ext] == "handlebars"
+
       # otherwise, allow if inside lproj
       next if entry.localized? || entry[:filename] =~ /^.+\.lproj\/.+$/
 


### PR DESCRIPTION
Previously handlebars templates couldn't be put into other locations. It would be nice to be able to bundle them into the view folder for bigger projects.
