### PR TITLE
Properly handle SCRIPT_NAME

### DIFF
--- a/lib/sproutcore.rb
+++ b/lib/sproutcore.rb
@@ -150,6 +150,9 @@ module SproutCore
     end
   end
 
+  def self.attach_prefix(url)
+    $script_name ? "#{$script_name}#{url}" : url
+  end
 end  # module SC
 
 SC = SproutCore # alias

--- a/lib/sproutcore/helpers/static_helper.rb
+++ b/lib/sproutcore/helpers/static_helper.rb
@@ -191,8 +191,10 @@ module SC
           end
         end
 
-        ret << %(<script type="text/javascript">SC.buildMode = "#{SC.build_mode}";</script>)
-        
+        url_prefix = $script_name ? %("#{$script_name}") : "null";
+
+        ret << %(<script type="text/javascript">SC.buildMode = "#{SC.build_mode}"; \n SC.urlPrefix = #{url_prefix}; </script>)
+
         return ret * "\n"
       end
 

--- a/lib/sproutcore/models/manifest_entry.rb
+++ b/lib/sproutcore/models/manifest_entry.rb
@@ -167,6 +167,7 @@ module SC
     def cacheable_url
       ret = self[:url]
       ret = [ret, self.timestamp].join('?') if target.config[:timestamp_urls]
+      ret = SC.attach_prefix(ret)
       if target.config[:hyper_domaining]
         ret = [self.hyperdomain_prefix(ret), ret].join('')
       end

--- a/lib/sproutcore/rack/builder.rb
+++ b/lib/sproutcore/rack/builder.rb
@@ -89,6 +89,9 @@ module SC
         project_mutex.synchronize do
           did_reload = reload_project! # if needed
 
+          # set SCRIPT_NAME to correctly set namespaces
+          $script_name = env["SCRIPT_NAME"]
+
           # collect some standard info
           url = env['PATH_INFO']
           url = '/sproutcore/welcome' if url == '/'


### PR DESCRIPTION
This commit is basically not very nice (ZOMG globals!), but currently there is no other nice way to pass stuff from env to views. It sets SC.urlPrefix in index.rhtml which can be used in javascript to attach proper prefix to url.
