### PR TITLE
Update Rack apps for 1.9.2

### DIFF
--- a/lib/sproutcore/rack/builder.rb
+++ b/lib/sproutcore/rack/builder.rb
@@ -176,7 +176,7 @@ module SC
         return [404, {
           "Content-Type"   => "text/html",
           "Content-Length" => reason.size.to_s
-        }, reason]
+        }, [reason]]
       end
 
       # Reloads the project if reloading is enabled.  At maximum this will

--- a/lib/sproutcore/rack/dev.rb
+++ b/lib/sproutcore/rack/dev.rb
@@ -28,15 +28,15 @@ module SC
         url = env['PATH_INFO']
         case url
         when '/sc/targets.json' # returns description of targets
-          return [200, {}, get_targets_json]
+          return [200, {}, [get_targets_json]]
 
         when '/sc/greenhouseconf.json' #returns json of all valid design objects
-          return [200, {}, get_greenhouse_configs(env)]
+          return [200, {}, [get_greenhouse_configs(env)]]
         else
-          return [404, {}, "not found"]
+          return [404, {}, ["not found"]]
         end
 
-        return [404, {}, "not found"]
+        return [404, {}, ["not found"]]
       end
 
       def get_targets_json

--- a/lib/sproutcore/rack/filesystem.rb
+++ b/lib/sproutcore/rack/filesystem.rb
@@ -65,7 +65,7 @@ module SC
         body = rqust.body.read()
         path = env["PATH_INFO"]
 
-        return [404, {}, "not found"] unless path =~ regex
+        return [404, {}, ["not found"]] unless path =~ regex
 
         path = path.sub regex, '' # remove path prefix
         action = params['action']
@@ -292,7 +292,7 @@ module SC
       end
 
       def success(msg)
-        [ 200, { 'Content-Type' => 'text/html' }, msg ]
+        [ 200, { 'Content-Type' => 'text/html' }, [msg] ]
       end
 
       def with_modifiable_path(path)

--- a/lib/sproutcore/rack/proxy.rb
+++ b/lib/sproutcore/rack/proxy.rb
@@ -80,7 +80,7 @@ module SC
           end
         end
 
-        return [404, {}, "not found"]
+        return [404, {}, ["not found"]]
       end
 
       def chunked?(headers)

--- a/lib/sproutcore/rack/test_runner.rb
+++ b/lib/sproutcore/rack/test_runner.rb
@@ -17,7 +17,7 @@ module SC
       end
 
       def call(env)
-        return [404, {}, "not found"]
+        return [404, {}, ["not found"]]
       end
     end
   end


### PR DESCRIPTION
I ran into some trouble while trying to use sproutcore with pow.cx. I added this config.ru to my sproutcore project

``` ruby
require 'rubygems'  
require 'bundler/setup'

require 'sproutcore'  

root = Pathname(__FILE__).dirname.expand_path  
project = SC::Project.load_nearest_project(root, :parent => SC.builtin_project)  
service = SC::Rack::Service.new(project)  
run service
```

But ran into errors while trying to fetch "/sc/targets.json"

It turns out the rack app that serves that file was passing a raw string as content and strings don't respond to #each as of 1.9.2 so it choked. This change makes SC::Rack::Dev and all of the other Rack apps in abbot that return a string return an array instead.

Sorry there aren't any failing tests. I couldn't find a convenient place to add them. All of the tests still pass.
