### PR TITLE
sort the composite test entries for determinism

### DIFF
--- a/lib/buildtasks/manifest.rake
+++ b/lib/buildtasks/manifest.rake
@@ -206,7 +206,7 @@ namespace :manifest do
           :build_task     => "build:test",
           :entry_type     => :test,
           :ext            => 'html',
-          :source_entries => entries,
+          :source_entries => SC::Helpers::EntrySorter.sort(entries),
           :hide_entries   => false
       end
 


### PR DESCRIPTION
We were experiencing test failures that were very hard to track down.  It turned out that our tests would fail if run in a different order.  Of course our tests shouldn't do this, but having the tests run in seemingly random order on different platforms is not a efficient way to find that out. 
