### PR TITLE
Fixes a bug with automatically following redirects to external hosts

### DIFF
--- a/lib/sproutcore/rack/proxy.rb
+++ b/lib/sproutcore/rack/proxy.rb
@@ -66,6 +66,18 @@ if SC::PROXY_ENABLED
       end
 
 
+      # clears host field from request header if it's redirected request
+      class RedirectHostHeaderKiller
+
+        def response(r)
+          if r.redirect?
+            puts r.req.headers
+            r.req.headers.delete('Host')
+          end
+        end
+
+      end
+
 
       # Rack application proxies requests as needed for the given project.
       class Proxy
@@ -147,6 +159,7 @@ if SC::PROXY_ENABLED
             headers = {}
             method = env['REQUEST_METHOD'].upcase
             status = 0
+            conn.use RedirectHostHeaderKiller
 
             case method
               when 'GET'


### PR DESCRIPTION
em-http-request automatically follows redirects, however it always keeps the host header from the original request. Therefore redirects to external hosts do not work.

This is related to what is described here: https://github.com/igrigorik/em-http-request/issues/110

I've added the small em-http-request middleware to clear the Host field from the request header in case of redirects so that the Host field gets set with the new host from the redirect response Location header.
