### PR TITLE
Updated Buildfile for templates. Changed required framework from 'core_foundation' to 'template_view'.

### DIFF
--- a/lib/gen/html_project/templates/@filename@/Buildfile
+++ b/lib/gen/html_project/templates/@filename@/Buildfile
@@ -1,5 +1,5 @@
 <%= copyright_block(namespace, :ruby) %>
 
 # Add initial buildfile information here
-config :all, :required => "sproutcore/core_foundation", :theme => "sproutcore/empty_theme"
+config :all, :required => "sproutcore/template_view", :theme => "sproutcore/empty_theme"
 

--- a/spec/fixtures/builder_tests/apps/handlebars_test/Buildfile
+++ b/spec/fixtures/builder_tests/apps/handlebars_test/Buildfile
@@ -1,1 +1,1 @@
-config :handlebars_test, :required => 'sproutcore/core_foundation'
+config :handlebars_test, :required => 'sproutcore/template_view'


### PR DESCRIPTION
Updated abbot's Buildfile templates to reflect the changes made to sproutcore/master regarding moving the template system out of 'core_foundation' and into it's own framework 'template_view'.
