### PR TITLE
Fixed spriting on Window

### DIFF
--- a/lib/sproutcore/builders/base.rb
+++ b/lib/sproutcore/builders/base.rb
@@ -68,7 +68,15 @@ module SC
           f.write line
         end
       end
-
+      
+      # writes the passed lines to the named file as binary
+      def writelinebinary(dst_path, line)
+        FileUtils.mkdir_p(File.dirname(dst_path))
+        File.open(dst_path, 'wb') do |f|
+          f.write line
+        end
+      end
+      
       # writes the passed lines to the named file
       def writelines(dst_path, lines)
         writeline(dst_path,joinlines(lines))

--- a/lib/sproutcore/builders/chance_file.rb
+++ b/lib/sproutcore/builders/chance_file.rb
@@ -36,7 +36,12 @@ module SC
 
       # Don't write empty files... but keep in mind that hte 
       if src.length > 0
-        writeline dst_path, src
+        if chance_file.end_with?("png")
+          # Writing it as binary to avoid newline problems on Windows
+          writelinebinary dst_path, src
+        else
+          writeline dst_path, src
+        end
       end
     end
 


### PR DESCRIPTION
A big thanks to @ialexi who helped me trouble shoot this problem.

The problem is that on Window when we write out to a file it was converting newlines to CRLF. This caused the PNG files to become invalid. 

To solve this problem I added check before writing chance stuff to a file. If it's writing a png file it will be written as binary, otherwise it will be written as normal. I checked both sc-server and sc-build on both OS X and Windows and spriting is working correctly in all permutations.

This fixes issue #78 .
