### PR TITLE
Fixed confusion issues with design/create/extend usage.

### DIFF
--- a/lib/gen/app/templates/apps/@target_name@/resources/main_page.js
+++ b/lib/gen/app/templates/apps/@target_name@/resources/main_page.js
@@ -2,15 +2,15 @@
 /*globals <%= namespace %> */
 
 // This page describes the main user interface for your application.  
-<%= namespace %>.mainPage = SC.Page.design({
+<%= namespace %>.mainPage = SC.Page.create({
 
   // The main pane is made visible on screen as soon as your app is loaded.
   // Add childViews to this pane for views to display immediately on page 
   // load.
-  mainPane: SC.MainPane.design({
+  mainPane: SC.MainPane.extend({
     childViews: 'labelView'.w(),
     
-    labelView: SC.LabelView.design({
+    labelView: SC.LabelView.extend({
       layout: { centerX: 0, centerY: 0, width: 200, height: 18 },
       textAlign: SC.ALIGN_CENTER,
       tagName: "h1", 

--- a/lib/gen/statechart_app/templates/apps/@target_name@/resources/main_page.js
+++ b/lib/gen/statechart_app/templates/apps/@target_name@/resources/main_page.js
@@ -2,15 +2,15 @@
 /*globals <%= namespace %> */
 
 // This page describes the main user interface for your application.  
-<%= namespace %>.mainPage = SC.Page.design({
+<%= namespace %>.mainPage = SC.Page.create({
 
   // The main pane is made visible on screen as soon as your app is loaded.
   // Add childViews to this pane for views to display immediately on page 
   // load.
-  mainPane: SC.MainPane.design({
+  mainPane: SC.MainPane.extend({
     childViews: 'labelView'.w(),
     
-    labelView: SC.LabelView.design({
+    labelView: SC.LabelView.extend({
       layout: { centerX: 0, centerY: 0, width: 200, height: 18 },
       textAlign: SC.ALIGN_CENTER,
       tagName: "h1", 


### PR DESCRIPTION
Fixed main_page.js to use .create() and .extend() instead of .design() for clarity as requested by geojeff and tce in IRC.
