### PR TITLE
Added support for moz-background-size and background-size to retina spriting.

### DIFF
--- a/vendor/chance/lib/chance/instance/spriting.rb
+++ b/vendor/chance/lib/chance/instance/spriting.rb
@@ -336,7 +336,9 @@ module Chance
           if slice[:x2]
             width = sprite[:width] / slice[:proportion]
             height = sprite[:height] / slice[:proportion]
-            output += ";  -webkit-background-size: #{width}px #{height}px"
+            output += ";  -webkit-background-size: #{width}px #{height}px\n"
+            output += ";  -moz-background-size: #{width}px #{height}px\n"
+            output += ";  background-size: #{width}px #{height}px\n"
           end
 
           output


### PR DESCRIPTION
When chance was authored only webkit supported background-size. For @2x support.
