### PR TITLE
Fix bug in SC::Generator#snake_case

### DIFF
--- a/lib/sproutcore/models/generator.rb
+++ b/lib/sproutcore/models/generator.rb
@@ -439,7 +439,7 @@ module SC
     def snake_case(str='')
       str = str.gsub(/-/, '_')
       str = str.gsub(/([^A-Z_])([A-Z][^A-Z]?)/,'\1_\2') # most cases
-      str = str.gsub(/([^_])([A-Z][^A-Z])/,'\1_\2') # HeadlineCNNNews
+      str = str.gsub(/([^_])([A-Z][^A-Z_])/,'\1_\2') # HeadlineCNNNews
       str.downcase
     end
 

--- a/spec/lib/models/generator/snake_case_spec.rb
+++ b/spec/lib/models/generator/snake_case_spec.rb
@@ -9,6 +9,7 @@ describe SC::Generator, 'snake_case' do
     { :input => "innerHTML", :output => "inner_html" },
     { :input => "Foo_Bar", :output => "foo_bar" },
     { :input => "Foo-Bar", :output => "foo_bar" },
+    { :input => "LOGGED_IN", :output => "logged_in" },
   ]
 
   test_hashes.each do |test_hash|


### PR DESCRIPTION
The snake_case method would transform "LOGGED_IN" into "logge_d_in".

The first commit adds a spec for the method, taking examples from the comments. The second commit fixes the bug and adds a test to the aforementioned spec.
