### PR TITLE
Handle correctly the UTF8 css files

### DIFF
--- a/vendor/chance/lib/chance/instance.rb
+++ b/vendor/chance/lib/chance/instance.rb
@@ -256,7 +256,7 @@ module Chance
         # slices (the details will be postprocessed out).
         # After that, all of the individual files (using the import CSS generated
         # in Step 1)
-        css = "@import \"#{image_css_path}\";\n" + import_css
+        css = "@charset \"UTF-8\";\n@import \"#{image_css_path}\";\n" + import_css
 
         # Step 3: Apply Sass Engine
         engine = Sass::Engine.new(css, Compass.sass_engine_options.merge({
@@ -431,6 +431,7 @@ module Chance
       }
 
       relative_paths = @mapped_files.invert
+      css = "@charset=\"UTF-8\";\n"
 
       @file_list.map {|file|
         # NOTE: WE MUST CALL CHANCE PARSER NOW, because it generates our slicses.


### PR DESCRIPTION
The current version of abbot is not handling correctly the UTF8 css files. This is particularly disturbing when using styles using _content:_ with unicode characters. This patch simply instructs scss to produce UTF8 files, using the @charset="UTF-8" statement on the 1st line of the generated scss files. Probably this operation could be done selectively but involves bigger changes into abbot.
