### PR TITLE
Adds exclude option to abbot.

### DIFF
--- a/lib/buildtasks/manifest.rake
+++ b/lib/buildtasks/manifest.rake
@@ -96,15 +96,16 @@ namespace :manifest do
     manifest = env[:manifest]
 
     # these directories are to be excluded unless CONFIG.load_"dirname" = true
-    dirnames = %w(debug tests fixtures protocols).reject do |k|
+    exclude_dirnames = %w(debug tests fixtures protocols).reject do |k|
       CONFIG[:"load_#{k}"]
     end
+    exclude_dirnames.concat [*CONFIG[:exclude]]
 
     # loop through entries and hide those that do not below...
     manifest.entries.each do |entry|
 
       # if in /dirname or /foo.lproj/dirname -- hide it!
-      dirnames.each do |dirname|
+      exclude_dirnames.each do |dirname|
         if entry[:filename] =~ /^(([^\/]+)\.lproj\/)?#{dirname}\/.+$/
           entry.hide!
           next

--- a/lib/sproutcore/tools/server.rb
+++ b/lib/sproutcore/tools/server.rb
@@ -17,11 +17,17 @@ module SC
                     :irb        => false,
                     :filesystem => true
     
-    method_option :whitelist, :type => :string,
+    method_option :whitelist,
+      :type => :string,
+      :default => "Whitelist",
       :desc => "The whitelist to use when building. By default, Whitelist (if present)"
-    method_option :blacklist, :type => :string,
+    method_option :blacklist,
+      :type => :string,
+      :default => "Blacklist",
       :desc => "The blacklist to use when building. By default, Blacklist (if present)"
-    method_option :accept, :type => :string,
+    method_option :accept,
+      :type => :string,
+      :default => "Accept",
       :desc => "The SproutCore Accept file to determine which files to include. By default, Accept (if present)"
 
     


### PR DESCRIPTION
The exclude option is a list of directories in the target that should not be included in builds.
