### PR TITLE
Adds a simple sc-phantom wrapper command.

### DIFF
--- a/bin/sc-phantom
+++ b/bin/sc-phantom
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+# ===========================================================================
+# Project:   Abbot - SproutCore Build Tools
+# Copyright: ©2010 Apple Inc.
+#            portions copyright @2006-2013 Strobe Inc.
+#            and contributors
+# ===========================================================================
+
+require "sproutcore"
+
+SC::Tools.invoke 'phantom'
+
+# EOF

--- a/lib/sproutcore/tools.rb
+++ b/lib/sproutcore/tools.rb
@@ -24,7 +24,7 @@ module SC
   # tool itself when it runs.
   #
   class Tools < ::Thor
-    check_unknown_options!
+    check_unknown_options! :except => :phantom
 
     def self.invoke(task_name)
       start([task_name.to_s] + ARGV)
@@ -465,4 +465,5 @@ require "sproutcore/tools/gen"
 require "sproutcore/tools/init"
 require "sproutcore/tools/manifest"
 require "sproutcore/tools/server"
+require "sproutcore/tools/phantom"
 

--- a/lib/sproutcore/tools/phantom.rb
+++ b/lib/sproutcore/tools/phantom.rb
@@ -1,0 +1,36 @@
+# ===========================================================================
+# Project:   Abbot - SproutCore Build Tools
+# Copyright: ©2009 Apple Inc.
+#            portions copyright @2006-2013 Strobe Inc.
+#            and contributors
+# ===========================================================================
+
+module SC
+
+  class Tools
+
+    stop_on_unknown_option! :phantom
+
+    desc "phantom ARGS", "Runs the PhantomJS unit test runner, passing arguments straight through"
+
+    def phantom(*args)
+      result = false
+      target = find_targets('/sproutcore').first
+
+      if target
+        test_runner_path = File.expand_path(File.join('phantomjs', 'test_runner.js'), target.source_root)
+        if File.file? test_runner_path
+          result = system "phantomjs #{test_runner_path} #{args.join(' ')}"
+        else
+          SC.logger.fatal "Could not find PhantomJS test runner"
+        end
+      else
+        SC.logger.fatal "Could not find /sproutcore target"
+      end
+
+      exit(1) unless result
+    end
+
+  end
+end
+

--- a/sproutcore.gemspec
+++ b/sproutcore.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json_pure', "~> 1.4"
   s.add_dependency 'extlib', "~> 0.9"
   s.add_dependency 'erubis', "~> 2.6"
-  s.add_dependency 'thor', '~> 0.14'
+  s.add_dependency 'thor', '~> 0.18'
   s.add_dependency 'sass', '~> 3.1'
   s.add_dependency 'haml', '~> 3.1'
 


### PR DESCRIPTION
As suggested by @publickeating, I added an sc-phantom command to make it easier to run
the PhantomJS test runner from an installed gem.

Note that I had to bump the version requirement for thor to get the ability to pass through arguments to PhantomJS.
