### PR TITLE
Use a filesystem change listener rather than polling for project changes

### DIFF
--- a/sproutcore.gemspec
+++ b/sproutcore.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
     s.add_dependency 'mongrel', '~> 1.1'
   else
     s.add_dependency 'thin', '~> 1.2'
+    s.add_dependency 'listen', '~> 2.0'
   end
 
   s.add_development_dependency 'gemcutter', "~> 0.6"


### PR DESCRIPTION
The sc-server thread that watches the project directory for changes to rebuild polls every two seconds, and for me consumes up to around 10% of a CPU just sitting there.  This pull implements the 'listen' gem, which uses inotify, fsevent, or other available facility to be notified of changes.  This drops idle CPU usage of sc-server to almost (but not quite) nothing.
